### PR TITLE
Allow customization of message shown if tests pass

### DIFF
--- a/Sources/LiteSupport/Run.swift
+++ b/Sources/LiteSupport/Run.swift
@@ -35,11 +35,13 @@ public func runLite(substitutions: [(String, String)],
                     pathExtensions: Set<String>,
                     testDirPath: String?,
                     testLinePrefix: String,
-                    parallelismLevel: ParallelismLevel = .none) throws -> Bool {
+                    parallelismLevel: ParallelismLevel = .none,
+                    successMessage: String = "All tests passed! 🎉") throws -> Bool {
   let testRunner = try TestRunner(testDirPath: testDirPath,
                                   substitutions: substitutions,
                                   pathExtensions: pathExtensions,
                                   testLinePrefix: testLinePrefix,
-                                  parallelismLevel: parallelismLevel)
+                                  parallelismLevel: parallelismLevel,
+                                  successMessage: successMessage)
   return try testRunner.run()
 }

--- a/Sources/LiteSupport/TestRunner.swift
+++ b/Sources/LiteSupport/TestRunner.swift
@@ -53,12 +53,16 @@ class TestRunner {
   /// How to parallelize work.
   let parallelismLevel: ParallelismLevel
 
+  /// The message to print if all the tests passed.
+  let successMessage: String
+
   /// Creates a test runner that will execute all tests in the provided
   /// directory.
   /// - throws: A LiteError if the test directory is invalid.
   init(testDirPath: String?, substitutions: [(String, String)],
        pathExtensions: Set<String>, testLinePrefix: String,
-       parallelismLevel: ParallelismLevel) throws {
+       parallelismLevel: ParallelismLevel,
+       successMessage: String) throws {
     let fm = FileManager.default
     var isDir: ObjCBool = false
     let testDirPath =
@@ -74,6 +78,7 @@ class TestRunner {
     self.pathExtensions = pathExtensions
     self.testLinePrefix = testLinePrefix
     self.parallelismLevel = parallelismLevel
+    self.successMessage = successMessage
   }
 
   func discoverTests() throws -> [TestFile] {
@@ -167,7 +172,7 @@ class TestRunner {
           """)
 
     if failures == 0 {
-      print("All tests passed! 🎉".green.bold)
+      print(successMessage.green.bold)
       return true
     }
     return false


### PR DESCRIPTION
### What's in this pull request?

A `successMessage` parameter is added to `runLite`, which provides the ability to customize the message shown if all the tests pass.

The default message "All tests pass! 🎉" displayed if no success message is specified.

The message is shown in bold green.

### What's worth discussing about this pull request?

Should the  user be able to customize the color and boldness as well?

### What downsides are there to merging this pull request?

🤷🏻‍♂️