### PR TITLE
Allow filtering which tests are run

### DIFF
--- a/Sources/LiteSupport/Run.swift
+++ b/Sources/LiteSupport/Run.swift
@@ -36,12 +36,14 @@ public func runLite(substitutions: [(String, String)],
                     testDirPath: String?,
                     testLinePrefix: String,
                     parallelismLevel: ParallelismLevel = .none,
-                    successMessage: String = "All tests passed! 🎉") throws -> Bool {
+                    successMessage: String = "All tests passed! 🎉",
+                    filters: [NSRegularExpression] = []) throws -> Bool {
   let testRunner = try TestRunner(testDirPath: testDirPath,
                                   substitutions: substitutions,
                                   pathExtensions: pathExtensions,
                                   testLinePrefix: testLinePrefix,
                                   parallelismLevel: parallelismLevel,
-                                  successMessage: successMessage)
+                                  successMessage: successMessage,
+                                  filters: filters)
   return try testRunner.run()
 }

--- a/Sources/LiteSupport/TestRunner.swift
+++ b/Sources/LiteSupport/TestRunner.swift
@@ -94,7 +94,7 @@ class TestRunner {
     var files = [TestFile]()
     for case let file as URL in enumerator {
       guard pathExtensions.contains(file.pathExtension) else { continue }
-      let nsPath = file.path as NSString
+      let nsPath = NSString(string: file.path)
       let matchesFilter = filters.contains {
         return $0.numberOfMatches(
           in: file.path,

--- a/Sources/lite-test/main.swift
+++ b/Sources/lite-test/main.swift
@@ -6,11 +6,12 @@ import LiteSupport
 
 /// Runs `lite` looking for `.test` files and executing them.
 do {
-  let allPassed = try runLite(substitutions: [("echo", "echo")],
-                              pathExtensions: ["test"],
-                              testDirPath: nil,
-                              testLinePrefix: "//",
-                              parallelismLevel: .automatic)
+  let allPassed = try runLite(
+    substitutions: [("echo", "echo")],
+    pathExtensions: ["test"],
+    testDirPath: nil,
+    testLinePrefix: "//",
+    parallelismLevel: .automatic)
   exit(allPassed ? 0 : -1)
 } catch let err as LiteError {
   fputs("error: \(err.message)", stderr)


### PR DESCRIPTION
### What's in this pull request?

This allows lite runners to add a `--filter` flag, similar to `lit.py --filter`.

### Why merge this pull request?

As `silt` gained more tests, it's becoming increasingly important to be able to just run a subset of tests.

### What's worth discussing about this pull request?

Is this the best API?

### What downsides are there to merging this pull request?

¯\\\_(ツ)\_/¯
