### PR TITLE
Swap out ShellOut for Basic.Process

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,12 +11,12 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.0.0"),
-    .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.1.0"),
+    .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
   ],
   targets: [
     .target(
       name: "LiteSupport",
-      dependencies: ["Rainbow", "ShellOut"]),
+      dependencies: ["Rainbow", "Utility"]),
 
     // This needs to be named `lite-test` instead of `lite` because consumers
     // of `lite` should use the target name `lite`.

--- a/Sources/LiteSupport/ParallelExecutor.swift
+++ b/Sources/LiteSupport/ParallelExecutor.swift
@@ -60,7 +60,7 @@ final class ParallelExecutor<TaskResult> {
   /// Adds a task to run asynchronously on the next worker. Workers are chosen
   /// in a round-robin fashion.
   func addTask(_ work: @escaping () -> TaskResult) {
-    queues[nextTask % queues.count].async(group: group) {
+    queues[nextTask % queues.count].async(group: group, qos: .userInitiated) {
       self.addResult(work())
     }
   }


### PR DESCRIPTION
Spawning new bash processes can take longer than just directly executing
the shell command.  Switch to Basic.Process.popen.
