### PR TITLE
Update dependencies, test on GitHub Actions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,9 +2,9 @@ name: Swift
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   swift-test:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,47 @@
+name: Swift
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  swift-test:
+    strategy:
+      matrix:
+        include:
+          - os: macos-10.15
+            swift_version: 5.2
+            xcode: /Applications/Xcode_11.7.app/Contents/Developer
+          - os: macos-10.15
+            swift_version: 5.3
+            xcode: /Applications/Xcode_12.app/Contents/Developer
+          - os: macos-11
+            swift_version: 5.4
+            xcode: /Applications/Xcode_12.5.app/Contents/Developer
+          - os: macos-11
+            swift_version: 5.5
+            xcode: /Applications/Xcode_13.0.app/Contents/Developer
+          - os: ubuntu-18.04
+            swift_version: 5.4
+          - os: ubuntu-20.04
+            swift_version: 5.4
+    name: Build on ${{ matrix.os }} with Swift ${{ matrix.swift_version }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test
+
+  windows-test:
+    runs-on: windows-2019
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: MaxDesiatov/swift-windows-action@v1
+        with:
+          shell-action: swift test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -38,6 +38,7 @@ jobs:
         run: swift test
 
   windows-test:
+    name: Build on Windows with Swift 5.4
     runs-on: windows-2019
 
     steps:

--- a/Package.swift
+++ b/Package.swift
@@ -11,12 +11,12 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.1.5"),
-    .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.4.0"),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.3"))
   ],
   targets: [
     .target(
       name: "LiteSupport",
-      dependencies: ["Rainbow", "SPMUtility"]),
+      dependencies: ["Rainbow", "SwiftToolsSupport-auto"]),
 
     // This needs to be named `lite-test` instead of `lite` because consumers
     // of `lite` should use the target name `lite`.

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.1.5"),
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.3"))
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.4"))
   ],
   targets: [
     .target(

--- a/Sources/LiteSupport/TestRunner.swift
+++ b/Sources/LiteSupport/TestRunner.swift
@@ -5,11 +5,10 @@
 /// This project is released under the MIT license, a copy of which is
 /// available in the repository.
 
+import Dispatch
 import Foundation
 import Rainbow
-import Basic
-import POSIX
-import Dispatch
+import TSCBasic
 
 /// Specifies how to parallelize test runs.
 public enum ParallelismLevel {
@@ -265,7 +264,7 @@ class TestRunner {
         stderr = error.description
         stdout = ""
         exitCode = Int(error.exitCode)
-      } catch let error as Basic.Process.Error {
+      } catch let error as TSCBasic.Process.Error {
         stderr = error.description
         stdout = ""
         exitCode = Int(EXIT_FAILURE)
@@ -291,35 +290,13 @@ extension SystemError {
       return errno
     case .close(let errno):
       return errno
-    case .dirfd(let errno, _):
-      return errno
     case .exec(let errno, _, _):
-      return errno
-    case .fgetc(let errno):
-      return errno
-    case .fread(let errno):
-      return errno
-    case .getcwd(let errno):
-      return errno
-    case .mkdir(let errno, _):
-      return errno
-    case .mkdtemp(let errno):
       return errno
     case .pipe(let errno):
       return errno
     case .posix_spawn(let errno, _):
       return errno
-    case .popen(let errno, _):
-      return errno
     case .read(let errno):
-      return errno
-    case .readdir(let errno, _):
-      return errno
-    case .realpath(let errno, _):
-      return errno
-    case .rename(let errno, _, _):
-      return errno
-    case .rmdir(let errno, _):
       return errno
     case .setenv(let errno, _):
       return errno
@@ -327,15 +304,9 @@ extension SystemError {
       return errno
     case .symlink(let errno, _, _):
       return errno
-    case .symlinkat(let errno, _):
-      return errno
-    case .unlink(let errno, _):
-      return errno
     case .unsetenv(let errno, _):
       return errno
     case .waitpid(let errno):
-      return errno
-    case .usleep(let errno):
       return errno
     }
   }


### PR DESCRIPTION
### What's in this pull request?

SwiftPM dependency is removed and `swift-tools-support-core` package is used instead. A minor change to `SystemError` was added to make it build.

I've also added a GitHub Actions workflow to test on macOS, Ubuntu, and Windows, since Travis seems to be no longer the best place for CI.

Resolves: Issue #8

### Why merge this pull request?

This allows using Lite with recent versions of Xcode.

### What's worth discussing about this pull request?

Do you think that transitioning to GitHub Actions is the best approach here?

### What downsides are there to merging this pull request?

The existing Travis build configuration will be abandoned.

